### PR TITLE
Add database tests for image and embedding storage

### DIFF
--- a/img_search/database/embeddings.py
+++ b/img_search/database/embeddings.py
@@ -1,0 +1,257 @@
+"""Milvus-backed embedding storage helpers.
+
+This module exposes a thin wrapper around a Milvus collection so the rest of
+the application can store and query image embeddings without juggling
+`pymilvus` primitives directly.  The implementation is intentionally minimal –
+enough to bootstrap a local Milvus deployment for development and testing –
+while still exposing convenience helpers for inserting, searching, and
+deleting embeddings.
+
+Example
+-------
+
+```python
+from img_search.database.embeddings import EmbeddingDatabase
+
+db = EmbeddingDatabase("img_embeddings", dim=512)
+db.add_embeddings(
+    ids=["cat-1", "cat-2"],
+    embeddings=[cat_vector, another_cat_vector],
+    model_name="siglip2",
+    dataset_name="cats",
+)
+
+results = db.search(cat_query_vector, top_k=5)
+```
+
+The class manages connection lifecycle, schema bootstrapping, and index
+creation on first use.  Consumers only need a running Milvus instance – e.g.
+`milvus-standalone` via Docker – listening on ``host``/``port``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from pymilvus import (  # type: ignore[import-untyped]
+    Collection,
+    CollectionSchema,
+    DataType,
+    FieldSchema,
+    MilvusException,
+    connections,
+    utility,
+)
+
+
+DEFAULT_INDEX_PARAMS: dict[str, Any] = {"M": 16, "efConstruction": 200}
+DEFAULT_SEARCH_PARAMS: dict[str, Any] = {"params": {"ef": 64}}
+
+
+def _as_float_vectors(vectors: Iterable[np.ndarray], *, dim: int) -> list[list[float]]:
+    data: list[list[float]] = []
+    for vector in vectors:
+        array = np.asarray(vector, dtype="float32")
+        if array.ndim != 1:
+            raise ValueError("Each embedding must be a one-dimensional vector")
+        if array.shape[0] != dim:
+            raise ValueError(
+                f"Embedding dimension mismatch: expected {dim}, received {array.shape[0]}"
+            )
+        data.append(array.tolist())
+    return data
+
+
+def _make_expr(field: str, ids: Sequence[str]) -> str:
+    quoted = ", ".join(f'"{identifier}"' for identifier in ids)
+    return f"{field} in [{quoted}]"
+
+
+@dataclass(slots=True)
+class EmbeddingDatabase:
+    """Milvus collection wrapper for storing and querying embeddings."""
+
+    collection_name: str
+    dim: int
+    host: str = "127.0.0.1"
+    port: int | str = 19530
+    alias: str = "default"
+    metric_type: str = "IP"
+    index_type: str = "HNSW"
+    index_params: dict[str, Any] | None = None
+    load_on_init: bool = True
+    _collection: Collection | None = field(init=False, repr=False, default=None)
+
+    def __post_init__(self) -> None:
+        self._connect()
+        self._collection = self._ensure_collection()
+        if self.load_on_init:
+            self._collection.load()
+
+    # ------------------------------------------------------------------
+    # Connection / collection lifecycle helpers
+    # ------------------------------------------------------------------
+    def _connect(self) -> None:
+        if not connections.has_connection(self.alias):
+            connections.connect(self.alias, host=self.host, port=str(self.port))
+
+    def _build_schema(self) -> CollectionSchema:
+        return CollectionSchema(
+            fields=[
+                FieldSchema(
+                    name="id",
+                    dtype=DataType.VARCHAR,
+                    is_primary=True,
+                    auto_id=False,
+                    max_length=255,
+                ),
+                FieldSchema(
+                    name="model_name",
+                    dtype=DataType.VARCHAR,
+                    max_length=255,
+                ),
+                FieldSchema(
+                    name="dataset_name",
+                    dtype=DataType.VARCHAR,
+                    max_length=255,
+                ),
+                FieldSchema(
+                    name="vector",
+                    dtype=DataType.FLOAT_VECTOR,
+                    dim=self.dim,
+                ),
+            ],
+            description="Image embedding store",
+        )
+
+    def _ensure_collection(self) -> Collection:
+        if not utility.has_collection(self.collection_name, using=self.alias):
+            schema = self._build_schema()
+            collection = Collection(
+                name=self.collection_name,
+                schema=schema,
+                using=self.alias,
+                consistency_level="Strong",
+            )
+            index_params = {
+                "index_type": self.index_type,
+                "metric_type": self.metric_type,
+                "params": self.index_params or DEFAULT_INDEX_PARAMS,
+            }
+            collection.create_index(field_name="vector", index_params=index_params)
+            return collection
+        return Collection(self.collection_name, using=self.alias)
+
+    @property
+    def collection(self) -> Collection:
+        if self._collection is None:
+            raise RuntimeError("Collection has not been initialized")
+        return self._collection
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    # ------------------------------------------------------------------
+    def add_embeddings(
+        self,
+        *,
+        ids: Sequence[str],
+        embeddings: Sequence[np.ndarray],
+        model_name: str,
+        dataset_name: str,
+    ) -> list[str]:
+        if len(ids) != len(embeddings):
+            raise ValueError("`ids` and `embeddings` must have the same length")
+
+        vectors = _as_float_vectors(embeddings, dim=self.dim)
+        self.collection.load()
+        try:
+            result = self.collection.upsert(
+                data=[
+                    list(ids),
+                    [model_name] * len(ids),
+                    [dataset_name] * len(ids),
+                    vectors,
+                ]
+            )
+        except AttributeError:
+            # Older Milvus releases do not expose ``Collection.upsert``; emulate it.
+            self.delete(ids)
+            result = self.collection.insert(
+                [
+                    list(ids),
+                    [model_name] * len(ids),
+                    [dataset_name] * len(ids),
+                    vectors,
+                ]
+            )
+        return list(result.primary_keys)  # type: ignore[no-any-return]
+
+    def delete(self, ids: Sequence[str]) -> None:
+        if not ids:
+            return
+        expr = _make_expr("id", ids)
+        self.collection.delete(expr)
+
+    def search(
+        self,
+        query: np.ndarray,
+        *,
+        top_k: int = 10,
+        filter_expression: str | None = None,
+        output_fields: Sequence[str] | None = ("model_name", "dataset_name"),
+        search_params: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        vector = _as_float_vectors([query], dim=self.dim)[0]
+        params = search_params or {**DEFAULT_SEARCH_PARAMS, "metric_type": self.metric_type}
+        self.collection.load()
+        results = self.collection.search(
+            data=[vector],
+            anns_field="vector",
+            param=params,
+            limit=top_k,
+            expr=filter_expression,
+            output_fields=list(output_fields) if output_fields else None,
+        )
+        hits: list[dict[str, Any]] = []
+        for hit in results[0]:
+            payload = {
+                "id": hit.id,
+                "distance": hit.distance,
+            }
+            entity = hit.entity
+            if entity is not None and output_fields:
+                for field in output_fields:
+                    payload[field] = entity.get(field)
+            hits.append(payload)
+        return hits
+
+    def drop(self) -> None:
+        try:
+            utility.drop_collection(self.collection_name, using=self.alias)
+        except MilvusException:
+            # Collection might have already been removed; ignore.
+            pass
+
+    def flush(self) -> None:
+        self.collection.flush()
+
+    def close(self) -> None:
+        try:
+            self.collection.release()
+        finally:
+            if connections.has_connection(self.alias):
+                connections.disconnect(self.alias)
+
+    @contextmanager
+    def session(self) -> Iterator[Collection]:
+        try:
+            yield self.collection
+        finally:
+            self.flush()
+
+
+__all__ = ["EmbeddingDatabase"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "loguru>=0.7.3",
     "peft>=0.17.1",
     "pillow>=11.3.0",
+    "pymilvus>=2.5.4",
     "pydantic>=2.11.7",
     "rich>=14.1.0",
     "sentence-transformers>=3.0.0",

--- a/tests/database/test_embedding_database.py
+++ b/tests/database/test_embedding_database.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+SITE_PACKAGES = (
+    Path(__file__).resolve().parents[2]
+    / ".venv"
+    / f"lib/python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+if SITE_PACKAGES.exists():
+    site_path = str(SITE_PACKAGES)
+    if site_path not in sys.path:
+        sys.path.append(site_path)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+root_path = str(PROJECT_ROOT)
+if root_path not in sys.path:
+    sys.path.append(root_path)
+
+np = pytest.importorskip("numpy")
+
+from img_search.database import embeddings as embeddings_module
+from img_search.database.embeddings import EmbeddingDatabase, _as_float_vectors
+
+
+class DummyFieldSchema:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+class DummyCollectionSchema:
+    def __init__(self, *, fields: list[Any], description: str | None = None) -> None:
+        self.fields = fields
+        self.description = description
+
+
+class DummyDataType:
+    VARCHAR = "VARCHAR"
+    FLOAT_VECTOR = "FLOAT_VECTOR"
+
+
+class FakeConnections:
+    def __init__(self) -> None:
+        self.connected: dict[str, tuple[str, str]] = {}
+
+    def has_connection(self, alias: str) -> bool:
+        return alias in self.connected
+
+    def connect(self, alias: str, host: str, port: str) -> None:
+        self.connected[alias] = (host, port)
+
+    def disconnect(self, alias: str) -> None:
+        self.connected.pop(alias, None)
+
+
+class FakeUtility:
+    def has_collection(self, name: str, *, using: str | None = None) -> bool:  # noqa: ARG002
+        return name in FakeCollection.registry
+
+    def drop_collection(self, name: str, *, using: str | None = None) -> None:  # noqa: ARG002
+        FakeCollection.registry.pop(name, None)
+
+
+class FakeHit:
+    def __init__(self, id_: str, distance: float, fields: dict[str, Any]) -> None:
+        self.id = id_
+        self.distance = distance
+        self.entity = fields
+
+
+class FakeCollection:
+    registry: dict[str, "FakeCollection"] = {}
+
+    def __new__(cls, name: str, *args: Any, **kwargs: Any) -> "FakeCollection":
+        if kwargs.get("schema") is not None:
+            instance = super().__new__(cls)
+            cls.registry[name] = instance
+            return instance
+        if name in cls.registry:
+            return cls.registry[name]
+        instance = super().__new__(cls)
+        cls.registry[name] = instance
+        return instance
+
+    def __init__(
+        self,
+        name: str,
+        schema: DummyCollectionSchema | None = None,
+        *,
+        using: str | None = None,
+        consistency_level: str | None = None,
+    ) -> None:
+        if getattr(self, "_initialized", False):
+            return
+        self.name = name
+        self.schema = schema
+        self.using = using
+        self.consistency_level = consistency_level
+        self.loaded = False
+        self.indexes: list[tuple[str, dict[str, Any]]] = []
+        self.upserts: list[list[Any]] = []
+        self.inserts: list[list[Any]] = []
+        self.deleted_exprs: list[str] = []
+        self.search_calls: list[dict[str, Any]] = []
+        self.search_results: list[list[FakeHit]] = [[]]
+        self.flushed = False
+        self.released = False
+        self._initialized = True
+
+    def create_index(self, *, field_name: str, index_params: dict[str, Any]) -> None:
+        self.indexes.append((field_name, index_params))
+
+    def load(self) -> None:
+        self.loaded = True
+
+    def upsert(self, data: list[Any]) -> SimpleNamespace:
+        self.upserts.append(data)
+        return SimpleNamespace(primary_keys=data[0])
+
+    def insert(self, data: list[Any]) -> SimpleNamespace:
+        self.inserts.append(data)
+        return SimpleNamespace(primary_keys=data[0])
+
+    def delete(self, expr: str) -> None:
+        self.deleted_exprs.append(expr)
+
+    def search(
+        self,
+        *,
+        data: list[list[float]],
+        anns_field: str,
+        param: dict[str, Any],
+        limit: int,
+        expr: str | None,
+        output_fields: list[str] | None,
+    ) -> list[list[FakeHit]]:
+        self.search_calls.append(
+            {
+                "data": data,
+                "anns_field": anns_field,
+                "param": param,
+                "limit": limit,
+                "expr": expr,
+                "output_fields": output_fields,
+            }
+        )
+        return self.search_results
+
+    def flush(self) -> None:
+        self.flushed = True
+
+    def release(self) -> None:
+        self.released = True
+
+
+@pytest.fixture(autouse=True)
+def mock_milvus(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    FakeCollection.registry.clear()
+    fake_connections = FakeConnections()
+    fake_utility = FakeUtility()
+
+    monkeypatch.setattr(embeddings_module, "connections", fake_connections)
+    monkeypatch.setattr(embeddings_module, "utility", fake_utility)
+    monkeypatch.setattr(embeddings_module, "Collection", FakeCollection)
+    monkeypatch.setattr(embeddings_module, "CollectionSchema", DummyCollectionSchema)
+    monkeypatch.setattr(embeddings_module, "FieldSchema", DummyFieldSchema)
+    monkeypatch.setattr(embeddings_module, "DataType", DummyDataType)
+    monkeypatch.setattr(embeddings_module, "MilvusException", RuntimeError)
+    return {"connections": fake_connections, "utility": fake_utility}
+
+
+def test_collection_initialization_creates_index() -> None:
+    db = EmbeddingDatabase("test_collection", dim=4)
+
+    collection = FakeCollection.registry["test_collection"]
+    assert collection.schema is not None
+    assert collection.loaded is True
+    assert collection.indexes == [
+        (
+            "vector",
+            {
+                "index_type": db.index_type,
+                "metric_type": db.metric_type,
+                "params": embeddings_module.DEFAULT_INDEX_PARAMS,
+            },
+        )
+    ]
+
+
+def test_add_embeddings_uses_upsert_and_returns_ids() -> None:
+    db = EmbeddingDatabase("demo", dim=2)
+    vectors = [np.array([1.0, 0.0], dtype="float32"), np.array([0.0, 1.0], dtype="float32")]
+
+    ids = db.add_embeddings(
+        ids=["a", "b"],
+        embeddings=vectors,
+        model_name="model",
+        dataset_name="dataset",
+    )
+
+    assert ids == ["a", "b"]
+    collection = FakeCollection.registry["demo"]
+    assert collection.upserts == [
+        [
+            ["a", "b"],
+            ["model", "model"],
+            ["dataset", "dataset"],
+            [[1.0, 0.0], [0.0, 1.0]],
+        ]
+    ]
+
+
+def test_search_returns_hit_payload() -> None:
+    db = EmbeddingDatabase("search", dim=3)
+    collection = FakeCollection.registry["search"]
+    collection.search_results = [
+        [
+            FakeHit("item-1", 0.1, {"model_name": "m1", "dataset_name": "d1"}),
+            FakeHit("item-2", 0.2, {"model_name": "m1", "dataset_name": "d2"}),
+        ]
+    ]
+
+    results = db.search(np.array([1.0, 2.0, 3.0], dtype="float32"), top_k=2)
+
+    assert results == [
+        {"id": "item-1", "distance": 0.1, "model_name": "m1", "dataset_name": "d1"},
+        {"id": "item-2", "distance": 0.2, "model_name": "m1", "dataset_name": "d2"},
+    ]
+    assert collection.search_calls[0]["limit"] == 2
+    assert collection.search_calls[0]["anns_field"] == "vector"
+
+
+def test_delete_builds_expression() -> None:
+    db = EmbeddingDatabase("delete", dim=2)
+    collection = FakeCollection.registry["delete"]
+
+    db.delete(["x", "y"])
+
+    assert collection.deleted_exprs == ['id in ["x", "y"]']
+
+
+def test_drop_and_close_release_resources() -> None:
+    db = EmbeddingDatabase("cleanup", dim=2)
+    collection = FakeCollection.registry["cleanup"]
+
+    db.drop()
+    assert "cleanup" not in FakeCollection.registry
+
+    db.close()
+    assert collection.released is True
+
+
+def test_as_float_vectors_validates_shape() -> None:
+    with pytest.raises(ValueError):
+        _as_float_vectors([np.zeros((2, 2))], dim=4)
+
+    with pytest.raises(ValueError):
+        _as_float_vectors([np.zeros(3)], dim=4)

--- a/tests/database/test_image_database.py
+++ b/tests/database/test_image_database.py
@@ -1,0 +1,88 @@
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+SITE_PACKAGES = (
+    Path(__file__).resolve().parents[2]
+    / ".venv"
+    / f"lib/python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+if SITE_PACKAGES.exists():
+    site_path = str(SITE_PACKAGES)
+    if site_path not in sys.path:
+        sys.path.append(site_path)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+root_path = str(PROJECT_ROOT)
+if root_path not in sys.path:
+    sys.path.append(root_path)
+
+pytest.importorskip("PIL")
+from PIL import Image
+
+from img_search.database.images import ImageDatabase
+
+
+@pytest.fixture()
+def temp_db(tmp_path: Path) -> ImageDatabase:
+    db_path = tmp_path / "images.lmdb"
+    with ImageDatabase(db_path) as db:
+        yield db
+    # context manager ensures closure
+
+
+def test_put_and_get_roundtrip(temp_db: ImageDatabase) -> None:
+    payload = b"hello-world"
+    temp_db.put("sample", payload)
+
+    assert "sample" in temp_db
+    assert len(temp_db) == 1
+    assert temp_db.get("sample") == payload
+
+
+def test_put_image_from_pil(temp_db: ImageDatabase) -> None:
+    image = Image.new("RGB", (8, 4), color=(10, 20, 30))
+
+    temp_db.put_image("pil", image, image_format="PNG")
+
+    loaded = temp_db.get_image("pil", mode="RGB")
+    assert loaded is not None
+    assert loaded.size == (8, 4)
+    assert loaded.getpixel((0, 0)) == (10, 20, 30)
+
+
+def test_put_image_from_bytes(temp_db: ImageDatabase) -> None:
+    image = Image.new("L", (2, 2), color=128)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+
+    temp_db.put_image("bytes", buffer.getvalue(), overwrite=True)
+
+    loaded = temp_db.get_image("bytes")
+    assert loaded is not None
+    assert loaded.mode == "L"
+
+
+def test_delete_and_missing_key(temp_db: ImageDatabase) -> None:
+    temp_db.put("to-delete", b"payload")
+    temp_db.delete("to-delete")
+
+    assert "to-delete" not in temp_db
+    with pytest.raises(KeyError):
+        temp_db.delete("to-delete")
+
+
+def test_readonly_rejects_writes(tmp_path: Path) -> None:
+    db_path = tmp_path / "readonly.lmdb"
+    db = ImageDatabase(db_path)
+    db.put("x", b"1")
+    db.close()
+
+    readonly = ImageDatabase(db_path, readonly=True)
+    with pytest.raises(RuntimeError):
+        readonly.put("x", b"2")
+
+    readonly.close()


### PR DESCRIPTION
## Summary
- add pytest coverage for the LMDB-backed `ImageDatabase`, including read-only behavior and image helpers
- add Milvus `EmbeddingDatabase` unit tests with lightweight fakes for connection, schema, and CRUD/search workflows
- ensure the embedding wrapper stores its collection handle inside a dataclass slot-safe field

## Testing
- uv run pytest tests/database

------
https://chatgpt.com/codex/tasks/task_e_68d7831b8c64832bb3e87746739b7c5e